### PR TITLE
Fixed authentication chain issue

### DIFF
--- a/rest_framework_httpsignature/authentication.py
+++ b/rest_framework_httpsignature/authentication.py
@@ -86,7 +86,11 @@ class SignatureAuthentication(authentication.BaseAuthentication):
         sent_string = request.META.get(authorization_header)
         if not sent_string:
             raise exceptions.AuthenticationFailed('No signature provided')
+
+        # Check if signature string matches signature pattern
         sent_signature = self.get_signature_from_signature_string(sent_string)
+        if not sent_signature:
+            return None
 
         # Fetch credentials for API key from the data store.
         try:

--- a/rest_framework_httpsignature/tests.py
+++ b/rest_framework_httpsignature/tests.py
@@ -177,11 +177,24 @@ class SignatureAuthenticationTestCase(TestCase):
         self.assertRaises(AuthenticationFailed,
                           self.auth.authenticate, request)
 
-    def test_bad_signature(self):
+    def test_no_signature(self):
         request = RequestFactory().get(
             ENDPOINT, {},
             HTTP_X_API_KEY=KEYID,
-            HTTP_AUTHORIZATION='some-wrong-value')
+            HTTP_AUTHORIZATION='no-signature')
+        res = self.auth.authenticate(request)
+        self.assertIsNone(res)
+
+    def test_bad_signature(self):
+        headers = ['(request-target)', 'accept', 'date', 'host']
+        signature = build_signature(
+            headers,
+            key_id=KEYID,
+            signature='some-wrong-value')
+        request = RequestFactory().get(
+            ENDPOINT, {},
+            HTTP_X_API_KEY=KEYID,
+            HTTP_AUTHORIZATION=signature)
         self.assertRaises(AuthenticationFailed,
                           self.auth.authenticate, request)
 


### PR DESCRIPTION
Authenticate method was raising AuthenticationFailed exception if the provided value for Authorization header does not match signature regular expression. It is ok if SignatureAuthentication is being used alone, but in an authentication chain, if another authentication class after SignatureAuthentication also uses Authorization header (for example TokenAuthentication) it will not work (AuthenticationFailed exception will break the chain).

I have changed authenticate method to return None if provided value for Authorization header does not match signature regular expression, allowing the next authentication class in the chain to handle it. AuthenticationFailed should be raised only if a wrong signature value is provided. 

I updated test_bad_signature and added test_no_signature.
